### PR TITLE
Add logic for range inclusion/exclusion

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,16 @@ function defaultFilter(row, { field, term, term_min, term_max, ...rest }) {
     } else if (term_min || term_max) {
       if (!term_min && term_min !== 0) term_min = -Infinity;
       if (!term_max && term_max !== 0) term_max = Infinity;
-      return term_min < value && value < term_max;
+
+      if (rest.inclusive === 'both') {
+        return (value >= term_min) && (value <= term_max);
+      }
+      if (rest.inclusive === 'left') {
+        return (value >= term_min) && (value < term_max);
+      }
+      if (rest.inclusive === 'right') {
+        return (value > term_min) && (value <= term_max);
+      }
     } else {
       throw new Error(`Couldn't find term or term_min/max (Probably unimplemented feature)`);
     }


### PR DESCRIPTION
Allows for filters such as

```javascript
age:[18 TO 21] // 18 to 21, including 18 and 21
age:{18 TO 21] // 19 to 21, excluding 18 and including 21
age:[18 TO 21} // 18 to 20, including 18 and excluding 21
age:{18 TO 21} // 19 to 20, excluding 18 and 21
```
